### PR TITLE
add thoth

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@
 
 #### Audit
 
+- [thoth](https://github.com/FuzzingLabs/thoth) - Cairo/StarkNet bytecode disassembler
+
 ## Editor Plugins
 
 #### Vim

--- a/README.md
+++ b/README.md
@@ -209,8 +209,6 @@
 - [starkops](https://github.com/seanjameshan/starkops) - StarkNet CLI
 - [voyager](https://voyager.online) - Block explorer.
 - [starktx](https://starktx.info/) - StarkTx Transaction Decoder.
-- [amarna](https://github.com/crytic/amarna) - Static-analyzer and linter for the Cairo programming language. 
-- [tayt](https://github.com/crytic/tayt) - StarkNet smart contract fuzzer.
 - [ape-cairo](https://github.com/ApeWorX/ape-cairo) - Compiler plugin for ape for the Cairo-lang.
 - [ape-starknet](https://github.com/ApeWorX/ape-starknet) - Ape plugin for the StarkNet networks.
 
@@ -220,7 +218,10 @@
 
 #### Audit
 
-- [thoth](https://github.com/FuzzingLabs/thoth) - Cairo/StarkNet bytecode disassembler
+- [amarna](https://github.com/crytic/amarna) - Static-analyzer and linter for the Cairo programming language. 
+- [tayt](https://github.com/crytic/tayt) - StarkNet smart contract fuzzer.
+- [thoth](https://github.com/FuzzingLabs/thoth) - Cairo/Starknet/Sierra analyzer, disassembler & decompiler
+- [cairo-fuzzer](https://github.com/FuzzingLabs/cairo-fuzzer) - Cairo/Starknet smart contract fuzzer
 
 ## Editor Plugins
 


### PR DESCRIPTION
we just released our Cairo/Starknet disassembler

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the
      raw markdown file).
- [x] Each description starts with an uppercase character and ends with a
      period.<br>Example: `cairo - The Cairo programming language.`
- [x] Drop all `A` / `An` prefixes at the start of the description.
- [x] Avoid using the word `StarkNet` in the description.
