### PR TITLE
starknet-vim for cairo v0.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@
 
 - [cairo.vim](https://github.com/miguelmota/cairo.vim) - (Outdated) vim syntax
   plugin for Cairo
+- [starknet-vim](https://github.com/0xHyoga/starknet-vim) - Vim syntax for Cairo v0.10
 
 #### Visual Studio Code
 


### PR DESCRIPTION
[Please describe your pull request here]

Vim plugin for Cairo v0.10. Syntax, linting and auto-formatting

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the
      raw markdown file).
- [x] Each description starts with an uppercase character and ends with a
      period.<br>Example: `cairo - The Cairo programming language.`
- [x] Drop all `A` / `An` prefixes at the start of the description.
- [x] Avoid using the word `StarkNet` in the description.
