### PR TITLE
feat: add pathfinder

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@
 - [juno](https://github.com/NethermindEth/juno) - Client (GoLang).
 - [nile](https://github.com/OpenZeppelin/nile) - CLI tool to develop StarkNet
   projects written in Cairo by OpenZeppelin
+- [pathfinder](https://github.com/eqlabs/pathfinder) - Full state node in Rust.
 - [protostar](https://docs.swmansion.com/protostar/) - CLI tool for developing and testing contracts in Cairo.
 - [starknet-devnet](https://github.com/Shard-Labs/starknet-devnet) - Local
   testnet


### PR DESCRIPTION
[Pathfinder](https://github.com/eqlabs/pathfinder) is a full state StarkNet node written in Rust.

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the
      raw markdown file).
- [x] Each description starts with an uppercase character and ends with a
      period.<br>Example: `cairo - The Cairo programming language.`
- [x] Drop all `A` / `An` prefixes at the start of the description.
- [x] Avoid using the word `StarkNet` in the description.
