### PR TITLE
feat: sort tools in alphabetical order

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,11 @@
 ## Tools
 
 #### General
-- [Braavos](https://chrome.google.com/webstore/detail/braavos-wallet/jnlgamecbpmbajjfhmmmlhejkemejdma) - Browser extension wallet.
+- [amarna](https://github.com/crytic/amarna) - Static-analyzer and linter for the Cairo programming language. 
+- [ape-cairo](https://github.com/ApeWorX/ape-cairo) - Compiler plugin for ape for the Cairo-lang.
+- [ape-starknet](https://github.com/ApeWorX/ape-starknet) - Ape plugin for the StarkNet networks.
 - [argent-x](https://github.com/argentlabs/argent-x) - Browser extension wallet
+- [Braavos](https://chrome.google.com/webstore/detail/braavos-wallet/jnlgamecbpmbajjfhmmmlhejkemejdma) - Browser extension wallet.
 - [cairo_kernel](https://github.com/ankitchiplunkar/cairo-jupyter) - Jupyter
   kernel for Cairo.
 - [fossil](https://github.com/OilerNetwork/fossil) - L1 state verification with STARKs.
@@ -207,12 +210,9 @@
 - [starknet-devnet](https://github.com/Shard-Labs/starknet-devnet) - Local
   testnet
 - [starkops](https://github.com/seanjameshan/starkops) - StarkNet CLI
-- [voyager](https://voyager.online) - Block explorer.
 - [starktx](https://starktx.info/) - StarkTx Transaction Decoder.
-- [amarna](https://github.com/crytic/amarna) - Static-analyzer and linter for the Cairo programming language. 
+- [voyager](https://voyager.online) - Block explorer.
 - [tayt](https://github.com/crytic/tayt) - StarkNet smart contract fuzzer.
-- [ape-cairo](https://github.com/ApeWorX/ape-cairo) - Compiler plugin for ape for the Cairo-lang.
-- [ape-starknet](https://github.com/ApeWorX/ape-starknet) - Ape plugin for the StarkNet networks.
 
 #### Utility
 


### PR DESCRIPTION
This PR sorts the entries in the tools section in alphabetical order as per [Contribution Guidelines](https://raw.githubusercontent.com/gakonst/awesome-starknet/master/CONTRIBUTING.md):
> - Additions should be added in alphabetical order of the relevant category.

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the
      raw markdown file).
- [x] Each description starts with an uppercase character and ends with a
      period.<br>Example: `cairo - The Cairo programming language.`
- [x] Drop all `A` / `An` prefixes at the start of the description.

Marking this as _fulfilled_ as I'm assuming the two items that do use the phrase had a valid reason to do so.
- [x] Avoid using the word `StarkNet` in the description.
