### PR TITLE
added two new libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@
 - [cairomate](https://github.com/a5f9t4/cairomate) - Structured, dependable legos for Starknet development. 
 - [caigo](https://github.com/dontpanicdao/caigo) - Golang Library.
 - [starknet-react](https://github.com/auclantis/starknet-react) - React hooks library.
+- [starknet-url](https://github.com/myBraavos/starknet-url) - Build & parse StarkNet URLs.
+- [starknet-deeplink](https://github.com/myBraavos/starknet-deeplink) - StarkNet deeplink generator.
 
 ## Tools
 


### PR DESCRIPTION
two new packages for generating StarkNet URI & deeplink URLs

## Checklist

- [ v] The URL is not already present in the list (check with CTRL/CMD+F in the
      raw markdown file).
- [ v] Each description starts with an uppercase character and ends with a
      period.<br>Example: `cairo - The Cairo programming language.`
- [ v] Drop all `A` / `An` prefixes at the start of the description.
- [ ] Avoid using the word `StarkNet` in the description.
