### PR TITLE
Add Starknet by Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@
 - [Skeleton for SHARP](https://perama-v.github.io/cairo/examples/building_blocks/skeleton/program_sharp.html)
   - SHARP programs differ from Cairo programs, this shows how to use
     SHARP for your own custom Cairo deploys (e.g. if you'd use StarkEx)
+- [Starknet by Example](https://starknet-by-example.voyager.online/) - Introduction to writing Starknet contracts in Cairo with simple examples.
 
 ##### Educational
 


### PR DESCRIPTION
Add [Starknet by Example](https://starknet-by-example.voyager.online/).

## Checklist

- [X] The URL is not already present in the list (check with CTRL/CMD+F in the
      raw markdown file).
- [X] Each description starts with an uppercase character and ends with a
      period.<br>Example: `cairo - The Cairo programming language.`
- [X] Drop all `A` / `An` prefixes at the start of the description.
- [X] Avoid using the word `StarkNet` in the description. (I think the single instance of "Starknet" is warranted in this case)
