### PR TITLE
fix: typo in a link

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@
 - [Snapshot proposals](https://snapshot.org/#/starknet.eth) - Snapshot proposals.
 - [Community discussions](https://community.starknet.io/c/governance/15)
 - [Delegate discovery](https://delegate.starknet.io/) - Finding delegates.
-- [Starknet Foundation](https://www.starknet.io/en/posts/governance/welcome-to-the-world-starknet-foundationn) - Introduction to the Starknet Foundation.
+- [Starknet Foundation](https://www.starknet.io/en/posts/governance/welcome-to-the-world-starknet-foundation) - Introduction to the Starknet Foundation.
 - [Starknet Foundation committees](https://www.starknet.io/en/posts/foundation/the-starknet-foundation-meet-the-committees) - Introduction to the Starknet Foundation committees.
 
 #### Events


### PR DESCRIPTION
Just fixing the typo in one of existing link.

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the
      raw markdown file).
- [x] Each description starts with an uppercase character and ends with a
      period.<br>Example: `cairo - The Cairo programming language.`
- [x] Drop all `A` / `An` prefixes at the start of the description.
- [x] Avoid using the word `Starknet` in the description.