### PR TITLE
Add Vim syntax highlighting and CoC LS links

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@
 - [Scarb](https://docs.swmansion.com/scarb) - The recommended build toolchain and package manager.
 - [Vscode Cairo extension](https://marketplace.visualstudio.com/items?itemName=starkware.cairo1) - Official Cairo extension for VSCode with diagnostics, go-to-definition, completion and more.
 - [Vim plugin for Scarb projects](https://github.com/swan-of-bodom/scarb-vim)
+- [Vim Syntax Highlighting](https://gist.github.com/b-j-roberts/3d58102660d3522d0a498edd776196f2)
+- [Vim CoC Scarb Language Server](https://gist.github.com/b-j-roberts/d5ca5381c79ea3cdc6558f2080789cf6)
 - [Starknet Foundry](https://foundry-rs.github.io/starknet-foundry/) - Toolchain for smart contracts development, testing and deployment.
   - [Starknet Foundry Forge Template](https://github.com/foundry-rs/starknet_forge_template)
 - [Starknet Remix](https://remix.ethereum.org/?#activate=Starknet) - The official Starknet plugin for Remix, a browser-based IDE without the need for any installation.

--- a/README.md
+++ b/README.md
@@ -197,8 +197,8 @@
 - [Scarb](https://docs.swmansion.com/scarb) - The recommended build toolchain and package manager.
 - [Vscode Cairo extension](https://marketplace.visualstudio.com/items?itemName=starkware.cairo1) - Official Cairo extension for VSCode with diagnostics, go-to-definition, completion and more.
 - [Vim plugin for Scarb projects](https://github.com/swan-of-bodom/scarb-vim)
-- [Vim Syntax Highlighting](https://gist.github.com/b-j-roberts/3d58102660d3522d0a498edd776196f2)
-- [Vim CoC Scarb Language Server](https://gist.github.com/b-j-roberts/d5ca5381c79ea3cdc6558f2080789cf6)
+- [Vim syntax highlighting](https://gist.github.com/b-j-roberts/3d58102660d3522d0a498edd776196f2) - Vimscript syntax file supporting Cairo 1 and 0.
+- [Vim CoC Scarb language server](https://gist.github.com/b-j-roberts/d5ca5381c79ea3cdc6558f2080789cf6) - Scarb language server setup for the coc.nvim plugin.
 - [Starknet Foundry](https://foundry-rs.github.io/starknet-foundry/) - Toolchain for smart contracts development, testing and deployment.
   - [Starknet Foundry Forge Template](https://github.com/foundry-rs/starknet_forge_template)
 - [Starknet Remix](https://remix.ethereum.org/?#activate=Starknet) - The official Starknet plugin for Remix, a browser-based IDE without the need for any installation.


### PR DESCRIPTION
Custom Vim setup links for Cairo1 syntax highlighting and coc.nvim language server.

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the
      raw markdown file).
- [x] Each description starts with an uppercase character and ends with a
      period.<br>Example: `cairo - The Cairo programming language.`
- [x] Drop all `A` / `An` prefixes at the start of the description.
- [x] Avoid using the word `Starknet` in the description.