### PR TITLE
Added types-js and starknet-devnet-js

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@
 - [scure-starknet](https://github.com/paulmillr/scure-starknet) - Minimal JS implementation of Starknet cryptography.
 - [wasm-cairo](https://github.com/cryptonerdcn/wasm-cairo) - Wasm bindings for Cairo.
 - [starknet-abigen-rs](https://github.com/glihm/starknet-abigen-rs) - Cairo ABI parser and generator in Rust.
-- [starknet-devnet-js](https://github.com/0xSpaceShard/starknet-devnet-js) - Interact with Starknet Devnet using this JS provider.
+- [starknet-devnet-js](https://github.com/0xSpaceShard/starknet-devnet-js) - Interact with the Devnet using this JS provider.
 
 #### Sequencers
 

--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@
 
 - [Starknet in Rust](https://github.com/lambdaclass/starknet_in_rust#starknet) - Rust implementation of Starknet execution logic.
 - [starknet-zig](https://github.com/starknet-io/starknet-zig) - Starknet library in Zig.
+- [types-js](https://github.com/starknet-io/types-js) - TypeScript types.
 - [types-rs](https://github.com/starknet-io/types-rs) - Rust types.
 - [poseidon-rs](https://github.com/keep-starknet-strange/poseidon-rs) - Poseidon Rust library.
 - [cairo_native](https://github.com/lambdaclass/cairo_native) - Compiler to convert Sierra to machine code via MLIR and LLVM.
@@ -275,6 +276,7 @@
 - [scure-starknet](https://github.com/paulmillr/scure-starknet) - Minimal JS implementation of Starknet cryptography.
 - [wasm-cairo](https://github.com/cryptonerdcn/wasm-cairo) - Wasm bindings for Cairo.
 - [starknet-abigen-rs](https://github.com/glihm/starknet-abigen-rs) - Cairo ABI parser and generator in Rust.
+- [starknet-devnet-js](https://github.com/0xSpaceShard/starknet-devnet-js) - Interact with Starknet Devnet using this JS provider.
 
 #### Sequencers
 


### PR DESCRIPTION
[Please describe your pull request here]

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the
      raw markdown file).
- [x] Each description starts with an uppercase character and ends with a
      period.<br>Example: `cairo - The Cairo programming language.`
- [x] Drop all `A` / `An` prefixes at the start of the description.
- [x] Avoid using the word `Starknet` in the description.