### PR TITLE
cainome link

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@
 - [tree-sitter-cairo](https://github.com/avnu-labs/tree-sitter-cairo) - Cairo 1.0 grammar for tree-sitter.
 - [scure-starknet](https://github.com/paulmillr/scure-starknet) - Minimal JS implementation of Starknet cryptography.
 - [wasm-cairo](https://github.com/cryptonerdcn/wasm-cairo) - Wasm bindings for Cairo.
-- [starknet-abigen-rs](https://github.com/glihm/starknet-abigen-rs) - Cairo ABI parser and generator in Rust.
+- [Cainome](https://github.com/cartridge-gg/cainome) - Library to generate bindings from Cairo ABI.
 
 #### Sequencers
 


### PR DESCRIPTION
Abigen is [deprecated](https://github.com/glihm/starknet-abigen-rs?tab=readme-ov-file#%EF%B8%8F-archived-%EF%B8%8F) in favor of Cainome

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the
      raw markdown file).
- [x] Each description starts with an uppercase character and ends with a
      period.<br>Example: `cairo - The Cairo programming language.`
- [x] Drop all `A` / `An` prefixes at the start of the description.
- [x] Avoid using the word `Starknet` in the description.