### PR TITLE
entro

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@
 - [Carbon Protocol](https://github.com/Carbonable/carbon-protocol) - Carbon Protocol written in Cairo.
 - [StarkRevoke](https://github.com/yusufferdogan/STARKREVOKE) - Revoke your ERC20 and ERC721 approvals.
 - [Batchor](https://github.com/keep-starknet-strange/batchor) - Batch your ERC20 transfers with a CSV file.
+- [entro](https://github.com/NethermindEth/entro) - CLI tool to backfill and decode chain data.
 
 ---
 


### PR DESCRIPTION
Entro is a convenient tool to explore Starknet via command line.

## Checklist

- [ ] The URL is not already present in the list (check with CTRL/CMD+F in the
      raw markdown file).
- [ ] Each description starts with an uppercase character and ends with a
      period.<br>Example: `cairo - The Cairo programming language.`
- [ ] Drop all `A` / `An` prefixes at the start of the description.
- [ ] Avoid using the word `Starknet` in the description.