### PR TITLE
Remove redundant link to archived Starknet Book

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@
 
 - [Starknet Website](https://www.starknet.io/) - Official Website.
 - [Starknet Documentation](https://docs.starknet.io/documentation/) - Official Documentation.
-- [The Starknet Book](https://book.starknet.io/) - In-depth guide.
 - [Cairo Documentation](https://www.cairo-lang.org/docs/index.html) - Official Cairo 1.0 Documentation.
 - [The Cairo Book](https://book.cairo-lang.org/) - In-depth guide to Cairo.
 - [YouTube channel](https://www.youtube.com/@starkware_ltd) - Official StarkWare YouTube channel.


### PR DESCRIPTION
Fixes #89

This PR removes the redundant link to The Starknet Book, which has been archived and now redirects to the same page as the Starknet Documentation.

Changes made:
- Removed the line: `- [The Starknet Book](https://book.starknet.io/) - In-depth guide.`

This change helps keep the resource list current and prevents confusion for users looking for Starknet documentation.