### PR TITLE
Update Cairo Documentation link to resolve 404 error

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@
 - [Starknet Website](https://www.starknet.io/) - Official Website.
 - [Starknet Documentation](https://docs.starknet.io/documentation/) - Official Documentation.
 - [The Starknet Book](https://book.starknet.io/) - In-depth guide.
-- [Cairo Documentation](https://www.cairo-lang.org/docs/index.html) - Official Cairo 1.0 Documentation.
+- [Cairo Documentation](https://docs.cairo-lang.org/) - Official Cairo 1.0 Documentation.
 - [The Cairo Book](https://book.cairo-lang.org/) - In-depth guide to Cairo.
 - [YouTube channel](https://www.youtube.com/@starkware_ltd) - Official StarkWare YouTube channel.
 - [Roadmap](https://www.starknet.io/en/roadmap) - What’s coming next for Starknet.


### PR DESCRIPTION
Fixes #91

This PR updates the link for Cairo Documentation to resolve the 404 error.

Changes made:
- Updated the Cairo Documentation link from https://www.cairo-lang.org/docs/index.html to https://docs.cairo-lang.org/

This change ensures users are directed to the correct, up-to-date Cairo documentation.