### PR TITLE
Remove outdated WTF Starknet resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,6 @@
 - [Starklings](https://github.com/shramee/starklings-cairo1) - Interactive tutorial to get you up and running with Cairo v1 and Starknet.
 - [Node Guardians](https://nodeguardians.io/dev-hub?s=devhub-campaigns) - Cairo 1.0 interactives tutorials.
 - [Starknet messaging tutorial](https://github.com/glihm/starknet-messaging-dev) - Detailed tutorial to test messaging with Anvil and Katana.
-- [WTF Starknet](https://github.com/WTFAcademy/WTF-Starknet) - English and Chinese tutorials.
 - [Starknet Lesson](https://www.starknet-lesson.com) - The latest and best Cairo course classroom.
 - [Cairo Zero to Hero](https://www.youtube.com/playlist?list=PLAHFj7-3e6Lz_gSRsearGALkTduJZFdlt) - Introduction to Starknet and Cairo.
 


### PR DESCRIPTION
Fixes #95 

This PR removes the WTF Starknet resource from the README due to multiple issues with outdated content and lack of maintenance.

Changes made:
- Removed the entry for WTF Starknet from the list of resources.

This change ensures that our list continues to provide only up-to-date and actively maintained resources, maintaining the quality and relevance of the Awesome Starknet list.