### PR TITLE
Add Exercism Cairo track to Tutorials and Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@
 - [Cairo by Example](https://cairo-by-example.com/) - Introduction to Cairo, with simple examples.
 - [Starklings](https://github.com/shramee/starklings-cairo1) - Interactive tutorial to get you up and running with Cairo v1 and Starknet.
 - [Node Guardians](https://nodeguardians.io/dev-hub?s=devhub-campaigns) - Cairo 1.0 interactives tutorials.
+- [Exercism Cairo Track](https://exercism.org/tracks/cairo) - Learn and master Cairo through hands-on exercises with community-powered mentorship.
 - [Starknet messaging tutorial](https://github.com/glihm/starknet-messaging-dev) - Detailed tutorial to test messaging with Anvil and Katana.
 - [WTF Starknet](https://github.com/WTFAcademy/WTF-Starknet) - English and Chinese tutorials.
 - [Starknet Lesson](https://www.starknet-lesson.com) - The latest and best Cairo course classroom.


### PR DESCRIPTION
Fixes #97 

This PR adds the Exercism Cairo track to the Tutorials and Examples section.

Changes made:
- Added an entry for the Exercism Cairo track in the Tutorials and Examples section.

This addition provides users with a structured, interactive approach to learning Cairo through hands-on exercises and community mentorship, enhancing the variety of learning resources in our list.