### PR TITLE
Adding Apiraba workshop

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@
 - [WTF Starknet](https://github.com/WTFAcademy/WTF-Starknet) - English and Chinese tutorials.
 - [Starknet Lesson](https://www.starknet-lesson.com) - The latest and best Cairo course classroom.
 - [Cairo Zero to Hero](https://www.youtube.com/playlist?list=PLAHFj7-3e6Lz_gSRsearGALkTduJZFdlt) - Introduction to Starknet and Cairo.
+- [Analyzing onchain data with Apibara Integrations](https://www.youtube.com/watch?v=XCxAvuutks4&list=PLcIyXLwiPilV5RBZj43AX1FY4FJMWHFTY&index=17&ab_channel=StarkWare) - Learn how to analyze onchain data on Starknet using Apibara and ChatGPT.
 
 #### Articles and Blogs
 


### PR DESCRIPTION
Partially fixes #126

Changes made: Adding Analyzing onchain data with Apibara Integrations workshop 

Reason to add this: This resource offers a practical guide on how to analyze on-chain data on Starknet using Apibara, integrating with ChatGPT. It provides valuable insights for developers and data analysts looking to leverage Starknet's data for various use cases.

