### PR TITLE
Add Become a Starknet Core Developer Talk

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@
 - [WTF Starknet](https://github.com/WTFAcademy/WTF-Starknet) - English and Chinese tutorials.
 - [Starknet Lesson](https://www.starknet-lesson.com) - The latest and best Cairo course classroom.
 - [Cairo Zero to Hero](https://www.youtube.com/playlist?list=PLAHFj7-3e6Lz_gSRsearGALkTduJZFdlt) - Introduction to Starknet and Cairo.
+- [Become a Starknet Core Developer](https://www.youtube.com/watch?v=7gT0XQA7WxQ&ab_channel=StarknetFoundation) - In-depth exploration of how to become a Core Developer on Starknet ecosystem.
 
 #### Articles and Blogs
 


### PR DESCRIPTION
Partially fixes #126

Changes made: Adding Become a Starknet Core Developer Conference. 

Reason to add this: This talk by Tomasz Stańczak, founder of Nethermind, provides an in-depth exploration of how to become a core developer within the Starknet ecosystem. It is an excellent resource for developers who want to contribute and don't know the path for it.

