### PR TITLE
Add Starknet OS architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@
 - [WTF Starknet](https://github.com/WTFAcademy/WTF-Starknet) - English and Chinese tutorials.
 - [Starknet Lesson](https://www.starknet-lesson.com) - The latest and best Cairo course classroom.
 - [Cairo Zero to Hero](https://www.youtube.com/playlist?list=PLAHFj7-3e6Lz_gSRsearGALkTduJZFdlt) - Introduction to Starknet and Cairo.
+- [Starknet OS Architecture](https://hackmd.io/@pragma/ByP-iux1T) - Walkthrough Starknet OS Cairo program.
 
 #### Articles and Blogs
 


### PR DESCRIPTION
Partially fixes #126 

Changes made: Added Starknet OS Architecture resource

Reason to add it: This resource created by Pragma walks through the Starknet OS Cairo program, giving a deep technical overview of its architecture.
