### PR TITLE
Add Kill Switch Contract Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@
 - [WTF Starknet](https://github.com/WTFAcademy/WTF-Starknet) - English and Chinese tutorials.
 - [Starknet Lesson](https://www.starknet-lesson.com) - The latest and best Cairo course classroom.
 - [Cairo Zero to Hero](https://www.youtube.com/playlist?list=PLAHFj7-3e6Lz_gSRsearGALkTduJZFdlt) - Introduction to Starknet and Cairo.
+- [Kill Switch Contract Example](https://github.com/starknet-edu/kill-switch) - Simple contract that can be called by any other contract using public read-only functions.
 
 #### Articles and Blogs
 


### PR DESCRIPTION
Partially fixes #126 

Changes made: Add Kill Switch contract repository. 

Reason to add it: This is a simple yet important example of a contract written with Cairo that can be called by any other contract, it's also used by other Starknet Foundation workshops so it's useful to have it as a learning resource here.

