### PR TITLE
Add StarknetCC 2024 recordings

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@
 - [WTF Starknet](https://github.com/WTFAcademy/WTF-Starknet) - English and Chinese tutorials.
 - [Starknet Lesson](https://www.starknet-lesson.com) - The latest and best Cairo course classroom.
 - [Cairo Zero to Hero](https://www.youtube.com/playlist?list=PLAHFj7-3e6Lz_gSRsearGALkTduJZFdlt) - Introduction to Starknet and Cairo.
+- [StarknetCC 2024 Talks](https://www.youtube.com/playlist?list=PLD-8OseqjVebIVnFkMphAUEKPjCUB0siq)
 
 #### Articles and Blogs
 


### PR DESCRIPTION
Partially fixes #126 

Changes made: Add Starknet CC recordings

Reason to add it: This playlist contains talks from Starknet CC 2024, providing access to a high quality information from various experts in the Starknet ecosystem. These talks are essential for staying up-to-date on the latest developments, use cases, and best practices in Starknet.

This should be updated after each StarknetCC
