### PR TITLE
Add Dojo workshop

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@
 - [WTF Starknet](https://github.com/WTFAcademy/WTF-Starknet) - English and Chinese tutorials.
 - [Starknet Lesson](https://www.starknet-lesson.com) - The latest and best Cairo course classroom.
 - [Cairo Zero to Hero](https://www.youtube.com/playlist?list=PLAHFj7-3e6Lz_gSRsearGALkTduJZFdlt) - Introduction to Starknet and Cairo.
+- [Build a Game with Dojo](https://www.youtube.com/watch?v=4tVW0zCE7ug&ab_channel=StarknetFoundation) - Learn how to build a game on Starknet with Dojo, a Provable Game Engine.
 
 #### Articles and Blogs
 


### PR DESCRIPTION
Partially fixes #126

Changes made: Adding Build a Game with Dojo workshop

Reason to add it: 
This tutorial teaches how to build a game using Dojo, a Provable Game Engine on Starknet. It’s valuable for developers interested in exploring the gaming and blockchain intersection, using Starknet’s infrastructure to create games with verifiable logic.

