### PR TITLE
Starknet.id link updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@
 
 - [Tokei](https://github.com/starknet-io/tokei) - ERC20 token streaming protocol.
 - [Focus Tree](https://github.com/focustree/contracts) - Focus Tree Contracts.
-- [Starknet.id](https://github.com/starknet-id) - On-chain identity.
+- [Starknet.id](https://github.com/lfglabs-dev) - On-chain identity.
 - [Carbon Protocol](https://github.com/Carbonable/carbon-protocol) - Carbon Protocol written in Cairo.
 - [StarkRevoke](https://github.com/yusufferdogan/STARKREVOKE) - Revoke your ERC20 and ERC721 approvals.
 - [Batchor](https://github.com/keep-starknet-strange/batchor) - Batch your ERC20 transfers with a CSV file.


### PR DESCRIPTION
Fixes #137

Changes made: update Starknet.id link to the current one (https://github.com/lfglabs-dev)
