### PR TITLE
typo Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@
 
 - [Starknet Community Forum](https://community.starknet.io/) - Official forum.
 - [Discord](https://starknet.io/discord) - Official Discord.
-- [Twitter](https://twitter.com/Starknet) - Official tarknet Twitter.
+- [Twitter](https://twitter.com/Starknet) - Official Starknet Twitter.
 - [Telegram Core Stars](https://t.me/sncorestars) - Cairo Core Stars Pharaohs group.
 - [Online communities](https://www.starknet.io/en/community/online-communities) - List of online communities.
 - [Starknet MEV](https://t.me/+TiNIOKAdIyQzNDg0) - MEV group.


### PR DESCRIPTION
### Typo found and corrected

<img width="574" alt="Снимок экрана 2024-11-03 в 13 15 11" src="https://github.com/user-attachments/assets/2c2880b8-aee6-4931-9331-88b08802906d">

In this text, there is a typo:

"tarknet Twitter" — it should be "**Starknet Twitter**".

Fixed.