### PR TITLE
Add walnut to developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@
   - [starknet-hardhat-example](https://github.com/0xSpaceShard/starknet-hardhat-example)
 - [docker-cairo](https://github.com/xJonathanLEI/docker-cairo) - Multi-arch Docker images with Cairo binaries.
 - [cairo-profiler](https://github.com/software-mansion/cairo-profiler) - Profiler for Cairo.
-
+- [walnut](https://app.walnut.dev/) - Walnut is a transaction debugger and simulator.
 
 
 #### Starknet SDKs

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@
   - [starknet-hardhat-example](https://github.com/0xSpaceShard/starknet-hardhat-example)
 - [docker-cairo](https://github.com/xJonathanLEI/docker-cairo) - Multi-arch Docker images with Cairo binaries.
 - [cairo-profiler](https://github.com/software-mansion/cairo-profiler) - Profiler for Cairo.
-- [walnut](https://app.walnut.dev/) - Walnut is a transaction debugger and simulator.
+- [walnut](https://walnut.dev/) - Walnut is a transaction debugger and simulator.
 
 
 #### Starknet SDKs


### PR DESCRIPTION
This PR adds the Walnut transaction debugger and simulator to the Developer Tools section.

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the
      raw markdown file).
- [x] Each description starts with an uppercase character and ends with a
      period.<br>Example: `cairo - The Cairo programming language.`
- [x] Drop all `A` / `An` prefixes at the start of the description.
- [x] Avoid using the word `Starknet` in the description.