### PR TITLE
Add Starknet Deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@
 - [Vim CoC Scarb language server](https://gist.github.com/b-j-roberts/d5ca5381c79ea3cdc6558f2080789cf6) - Scarb language server setup for the coc.nvim plugin.
 - [Starknet Foundry](https://foundry-rs.github.io/starknet-foundry/) - Toolchain for smart contracts development, testing and deployment.
 - [Starknet Remix](https://remix.ethereum.org/?#activate=Starknet) - The official Starknet plugin for Remix, a browser-based IDE without the need for any installation.
-- [Starknet Deploy](https://github.com/olas-protocol/starknet-deploy) - Tool to streamline the deployment and interaction of StarkNet contracts.
+- [Starknet Deploy](https://github.com/olas-protocol/starknet-deploy) - Tool to streamline the deployment and interaction of contracts.
 - [Starknet Devnet](https://github.com/0xSpaceShard/starknet-devnet-rs) - Local testnet.
 - [Katana](https://book.dojoengine.org/toolchain/katana) - High performance sequencer that can be used as a local testnet.
 - [Starknet Hardhat plugin](https://github.com/Shard-Labs/starknet-hardhat-plugin) - The Starknet Hardhat plugin.

--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@
 - [Vim CoC Scarb language server](https://gist.github.com/b-j-roberts/d5ca5381c79ea3cdc6558f2080789cf6) - Scarb language server setup for the coc.nvim plugin.
 - [Starknet Foundry](https://foundry-rs.github.io/starknet-foundry/) - Toolchain for smart contracts development, testing and deployment.
 - [Starknet Remix](https://remix.ethereum.org/?#activate=Starknet) - The official Starknet plugin for Remix, a browser-based IDE without the need for any installation.
+- [Starknet Deploy](https://github.com/olas-protocol/starknet-deploy) - Tool to streamline the deployment and interaction of StarkNet contracts.
 - [Starknet Devnet](https://github.com/0xSpaceShard/starknet-devnet-rs) - Local testnet.
 - [Katana](https://book.dojoengine.org/toolchain/katana) - High performance sequencer that can be used as a local testnet.
 - [Starknet Hardhat plugin](https://github.com/Shard-Labs/starknet-hardhat-plugin) - The Starknet Hardhat plugin.


### PR DESCRIPTION
This PR adds the Starknet Deploy to  Developer Tools section.

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the
      raw markdown file).
- [x] Each description starts with an uppercase character and ends with a
      period.<br>Example: `cairo - The Cairo programming language.`
- [x] Drop all `A` / `An` prefixes at the start of the description.
- [x] Avoid using the word `Starknet` in the description.